### PR TITLE
add possibility to query active or inactive slides

### DIFF
--- a/modules/homepage-slider/homepage-slider.service.js
+++ b/modules/homepage-slider/homepage-slider.service.js
@@ -18,8 +18,10 @@ const {
 } = require('../translations/translations.service');
 
 class HomePageSliderService {
-  async getAllSlides({ skip, limit }) {
+  async getAllSlides({ skip, limit, show_statuses = [true, false] }) {
     const items = await HomePageSlider.find()
+      .where('show')
+      .in(show_statuses)
       .sort({ show: -1, order: 1 })
       .skip(skip)
       .limit(limit)

--- a/typeDefs.js
+++ b/typeDefs.js
@@ -667,7 +667,7 @@ const typeDefs = gql`
     getEmailQuestionById(id: ID!): EmailQuestionResult
     getHomePageLooksImages: [HomePageImages]
     getPendingEmailQuestionsCount: Int
-    getAllSlides(limit: Int, skip: Int): PaginatedHomePageSlides!
+    getAllSlides(limit: Int, skip: Int, show_statuses: Boolean): PaginatedHomePageSlides!
     getSlideById(id: ID!): HomePageSlideResult
     getAllSizes(limit: Int, skip: Int, filter:SizeFilterInput): SizeItems
     getSizeById(id: ID!): Size


### PR DESCRIPTION
## Description

Now by adding additional property (show_statutes: true | false) you can get active or inactive slides



#### Screenshots

Original             |  Updated
:-------------------------:|:-------------------------:
![Clip2net_220405191254](https://user-images.githubusercontent.com/49586997/161806249-af0e494a-1c17-4c0c-8d96-f07252b3fd5b.png) | ![Clip2net_220405191132](https://user-images.githubusercontent.com/49586997/161806367-5e2738d0-134b-4492-9e86-1e49fc450377.png)



### Checklist
- [ ] 🔽 My branch is up-to-date with "development" branch
- [ ] ✅All tests passed locally
- [ ] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [ ] 🔗 Link pull request to issue
