### PR TITLE
Bugfix/1176/add first name last name to certificates service

### DIFF
--- a/modules/certificate/certificate.service.js
+++ b/modules/certificate/certificate.service.js
@@ -40,6 +40,10 @@ class CertificatesService {
       .sort({ startDate: 1 })
       .limit(limit)
       .skip(skip)
+      .populate({
+        path: 'createdBy',
+        select: 'firstName lastName',
+      })
       .exec();
 
     const count = await CertificateModel.find(filter).countDocuments().exec();


### PR DESCRIPTION
## Description

I have added firstName lastName to CertificatesService , because at the admin page pagination didn't work correctly.
After rendering the page using useEffect and dispatching getUsers at admin certificates page we saw at first - count of all users and than after next click - count of all certificates. 
After removing useEffect the problem was fixed.



#### Screenshots

Original 
 ![](https://clip2net.com/clip/m0/c81a3-clip-64kb.png?nocache=1) 
Updated
 ![](https://clip2net.com/clip/m0/e23c2-clip-41kb.png?nocache=1) 


### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [x] 🔗 Link pull request to issue
