### PR TITLE
rewrite international fields validation

### DIFF
--- a/validators/order.validator.js
+++ b/validators/order.validator.js
@@ -189,34 +189,35 @@ const nestedDeliveryValidator = Joi.object({
     currency: Joi.string().trim().required(),
     value: Joi.number().required(),
   }),
-  messenger: Joi.string().when(SENT_BY, {
+  messenger: Joi.string().allow('').when(SENT_BY, {
     is: WORLDWIDE,
     then: Joi.string().required(),
   }),
-  messengerPhone: Joi.string().when(SENT_BY, {
-    is: WORLDWIDE,
-    then: Joi.string().trim().required().regex(numberRegExp),
-  }),
-  worldWideCountry: Joi.string().when(SENT_BY, {
-    is: WORLDWIDE,
-    then: Joi.string().required(),
-  }),
-  stateOrProvince: Joi.string().when(SENT_BY, {
-    is: WORLDWIDE,
-    then: Joi.string().allow(null, '').optional(),
-  }),
-  worldWideCity: Joi.string().when(SENT_BY, {
+  messengerPhone: Joi.string()
+    .allow('')
+    .when(SENT_BY, {
+      is: WORLDWIDE,
+      then: Joi.string().required().regex(numberRegExp),
+    }),
+  worldWideCountry: Joi.string().allow('').when(SENT_BY, {
     is: WORLDWIDE,
     then: Joi.string().required(),
   }),
-  worldWideStreet: Joi.string().when(SENT_BY, {
+  stateOrProvince: Joi.string().allow(null, '').optional(),
+  worldWideCity: Joi.string().allow('').when(SENT_BY, {
     is: WORLDWIDE,
     then: Joi.string().required(),
   }),
-  cityCode: Joi.string().when(SENT_BY, {
+  worldWideStreet: Joi.string().allow('').when(SENT_BY, {
     is: WORLDWIDE,
-    then: Joi.string().required().regex(onlyNumbersRegExp),
+    then: Joi.string().required(),
   }),
+  cityCode: Joi.string()
+    .allow('')
+    .when(SENT_BY, {
+      is: WORLDWIDE,
+      then: Joi.string().required().regex(onlyNumbersRegExp),
+    }),
 });
 
 const orderValidator = Joi.object({


### PR DESCRIPTION
## Description

Now, international delivery fields are not required when creating an order on admin of type, for instance, selfpickup, or nova post.




### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [x] 🔗 Link pull request to issue
