### PR TITLE
remove some required rules when sent by courier of ukrpost or novapost

### DIFF
--- a/validators/order.validator.js
+++ b/validators/order.validator.js
@@ -98,20 +98,10 @@ const nestedDeliveryValidator = Joi.object({
       then: Joi.string().required(),
       otherwise: Joi.string().only(''),
     }),
-  regionId: Joi.string()
-    .when(SENT_BY, {
-      is: UKRPOST,
-      then: Joi.string().required(),
-    })
-    .when(SENT_BY, {
-      is: UKRPOSTCOURIER,
-      then: Joi.string().required(),
-    })
-    .when(SENT_BY, {
-      is: NOVAPOSTCOURIER,
-      then: Joi.string().required(),
-      otherwise: Joi.string().only(''),
-    }),
+  regionId: Joi.string().allow('').when(SENT_BY, {
+    is: UKRPOST,
+    then: Joi.string().required(),
+  }),
   district: Joi.string()
     .when(SENT_BY, {
       is: NOVAPOSTCOURIER,
@@ -126,20 +116,10 @@ const nestedDeliveryValidator = Joi.object({
       then: Joi.string().required(),
       otherwise: Joi.string().only(''),
     }),
-  districtId: Joi.string()
-    .when(SENT_BY, {
-      is: UKRPOST,
-      then: Joi.string().required(),
-    })
-    .when(SENT_BY, {
-      is: NOVAPOSTCOURIER,
-      then: Joi.string().required(),
-    })
-    .when(SENT_BY, {
-      is: UKRPOSTCOURIER,
-      then: Joi.string().required(),
-      otherwise: Joi.string().only(''),
-    }),
+  districtId: Joi.string().allow('').when(SENT_BY, {
+    is: UKRPOST,
+    then: Joi.string().required(),
+  }),
   city: Joi.string()
     .when(SENT_BY, {
       is: NOVAPOSTCOURIER,
@@ -158,20 +138,10 @@ const nestedDeliveryValidator = Joi.object({
       then: Joi.string().required(),
       otherwise: Joi.string().only(''),
     }),
-  cityId: Joi.string()
-    .when(SENT_BY, {
-      is: UKRPOST,
-      then: Joi.string().required(),
-    })
-    .when(SENT_BY, {
-      is: NOVAPOSTCOURIER,
-      then: Joi.string().required(),
-    })
-    .when(SENT_BY, {
-      is: UKRPOSTCOURIER,
-      then: Joi.string().required(),
-      otherwise: Joi.string().only(''),
-    }),
+  cityId: Joi.string().allow('').when(SENT_BY, {
+    is: UKRPOST,
+    then: Joi.string().required(),
+  }),
   street: deliveryCheckerValidator,
   house: deliveryCheckerValidator,
   flat: Joi.string()


### PR DESCRIPTION
## Description

regionId, districtId, cityId should not be required when making an order as courier of nova post or ukr post because user will not be able to make an order when passing its own region, district or city (another situation is when API does not work)


### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [ ] 🔗 Link pull request to issue
