### PR TITLE
Bugfix/1225/upload service outdated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1699,18 +1699,6 @@
             "tslib": "^2.0.3"
           }
         },
-        "graphql-upload": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-12.0.0.tgz",
-          "integrity": "sha512-ovZ3Q7sZ17Bmn8tYl22MfrpNR7nYM/DUszXWgkue7SFIlI9jtqszHAli8id8ZcnGBc9GF0gUTNSskYWW+5aNNQ==",
-          "requires": {
-            "busboy": "^0.3.1",
-            "fs-capacitor": "^6.2.0",
-            "http-errors": "^1.8.0",
-            "isobject": "^4.0.0",
-            "object-path": "^0.11.5"
-          }
-        },
         "pascal-case": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
@@ -3861,22 +3849,14 @@
           "integrity": "sha512-8S4f4WsCryNw2mJJchi46YgB6CR5Ze+4L1h8ewl9tEpL4SJ3ZO+c/bS4BWhB8bK+O3TMqhuZarTitd0S0eh2pA=="
         },
         "graphql-upload": {
-          "version": "12.0.0",
-          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-12.0.0.tgz",
-          "integrity": "sha512-ovZ3Q7sZ17Bmn8tYl22MfrpNR7nYM/DUszXWgkue7SFIlI9jtqszHAli8id8ZcnGBc9GF0gUTNSskYWW+5aNNQ==",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.1.0.tgz",
+          "integrity": "sha512-U2OiDI5VxYmzRKw0Z2dmfk0zkqMRaecH9Smh1U277gVgVe9Qn+18xqf4skwr4YJszGIh7iQDZ57+5ygOK9sM/Q==",
           "requires": {
             "busboy": "^0.3.1",
-            "fs-capacitor": "^6.2.0",
-            "http-errors": "^1.8.0",
-            "isobject": "^4.0.0",
-            "object-path": "^0.11.5"
-          },
-          "dependencies": {
-            "fs-capacitor": {
-              "version": "6.2.0",
-              "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-6.2.0.tgz",
-              "integrity": "sha512-nKcE1UduoSKX27NSZlg879LdQc94OtbOsEmKMN2MBNudXREvijRKx2GEBsTMTfws+BrbkJoEuynbGSVRSpauvw=="
-            }
+            "fs-capacitor": "^2.0.4",
+            "http-errors": "^1.7.3",
+            "object-path": "^0.11.4"
           }
         }
       }
@@ -9017,6 +8997,18 @@
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.3.2.tgz",
       "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
     },
+    "graphql-upload": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-11.0.0.tgz",
+      "integrity": "sha512-zsrDtu5gCbQFDWsNa5bMB4nf1LpKX9KDgh+f8oL1288ijV4RxeckhVozAjqjXAfRpxOHD1xOESsh6zq8SjdgjA==",
+      "requires": {
+        "busboy": "^0.3.1",
+        "fs-capacitor": "^6.1.0",
+        "http-errors": "^1.7.3",
+        "isobject": "^4.0.0",
+        "object-path": "^0.11.4"
+      }
+    },
     "graphql-ws": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/graphql-ws/-/graphql-ws-4.1.0.tgz",
@@ -9278,15 +9270,22 @@
       "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-errors": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.0.tgz",
-      "integrity": "sha512-4I8r0C5JDhT5VkvI47QktDW75rNlGVsUf/8hzjCC/wkWI/jdTRmBb9aI7erSG82r1bjKY3F6k28WnsVxB1C73A==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
+        "toidentifier": "1.0.1"
+      },
+      "dependencies": {
+        "toidentifier": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+          "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+        }
       }
     },
     "http-proxy-agent": {
@@ -13192,9 +13191,9 @@
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-path": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
-      "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.8.tgz",
+      "integrity": "sha512-YJjNZrlXJFM42wTBn6zgOJVar9KFJvzx6sTWDte8sWZF//cnjl0BxHNpfZx+ZffXX63A9q0b1zsFiBX4g4X5KA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -15548,7 +15547,7 @@
     "streamsearch": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+      "integrity": "sha512-jos8u++JKm0ARcSUTAZXOVC0mSox7Bhn6sBgty73P1f3JGf7yG2clTbBNHUdde/kdvP2FESam+vM6l8jBrNxHA=="
     },
     "string-argv": {
       "version": "0.3.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "private": "true",
   "resolutions": {
-    "apollo-server-core/fs-capacitor": "^6.2.0",
-    "graphql-upload": "^12.0.0"
+    "**/**/fs-capacitor": "^6.2.0",
+    "**/graphql-upload": "^12.0.0"
   },
   "scripts": {
     "start": "cross-env NODE_ENV=development nodemon server.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "private": "true",
   "resolutions": {
-    "**/**/fs-capacitor": "^6.2.0",
+    "**/fs-capacitor": "^6.2.0",
     "**/graphql-upload": "^12.0.0"
   },
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const { applyMiddleware } = require('graphql-middleware');
 const express = require('express');
 const cors = require('cors');
 const { createServer } = require('http');
+const { graphqlUploadExpress } = require('graphql-upload');
 
 const typeDefs = require('./typeDefs');
 const resolvers = require('./resolvers');
@@ -53,6 +54,7 @@ const schema = applyMiddleware(
 
 const server = new ApolloServer({
   schema,
+  uploads: false,
   context: async ({ req, connection }) => {
     if (connection) {
       return connection.context;
@@ -131,6 +133,7 @@ app.disable('x-powered-by');
 
 currencyWorker();
 
+app.use('/graphql', graphqlUploadExpress());
 app.post('/fondy/certificates_callback', checkCertificatesPaymentStatus);
 app.post('/fondy/order_callback', checkOrderPaymentStatus);
 app.get('/translations', translationsService.getAllTranslations);


### PR DESCRIPTION
## Description

The graphql-upload service is outdated, which is why a use of graphql-upload middleware had to be added to the app. 

### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [x] 🔗 Link pull request to issue
