### PR TITLE
delete redundant getCertificateByName and fixed

### DIFF
--- a/modules/certificate/certificate.graphql.js
+++ b/modules/certificate/certificate.graphql.js
@@ -16,7 +16,7 @@ const certificateTypes = `
     paymentToken: String
     admin: [Admin]
   }
-  
+
   type Admin{
     firstName: String
     lastName: String
@@ -64,7 +64,7 @@ const certificateTypes = `
   extend type Query {
     getAllCertificates(limit: Int, skip: Int, sortBy: String, sortOrder: Sort, search: String, status: [String]): CertificatePaginatedResult
     getCertificateById(id: ID!): CertificateResult
-    getCertificateByName(name: String!): CertificateResult
+    getCertificateByParams(params: CertificateInput!): CertificateResult
   }
 
   extend type Mutation {

--- a/modules/certificate/certificate.resolver.js
+++ b/modules/certificate/certificate.resolver.js
@@ -27,9 +27,9 @@ const certificatesQuery = {
   getCertificateById: async (_, { id }) =>
     certificatesService.getCertificateById(id),
 
-  getCertificateByName: async (_, { name }) => {
+    getCertificateByParams: async (_, { params }) => {
     try {
-      return await certificatesService.getCertificateByName(name);
+      return await certificatesService.getCertificateByParams(params);
     } catch (e) {
       return new ApolloError(e.message, e.statusCode);
     }

--- a/modules/certificate/certificate.service.js
+++ b/modules/certificate/certificate.service.js
@@ -109,24 +109,7 @@ class CertificatesService extends FilterHelper {
 
     return certificate;
   }
-
-  async getCertificateByName(name) {
-    const certificate = await CertificateModel.findOne({ name }).exec();
-
-    if (!certificate) {
-      throw new RuleError(CERTIFICATE_NOT_FOUND, NOT_FOUND);
-    }
-    if (certificate.isUsed) {
-      throw new RuleError(CERTIFICATE_IS_USED, BAD_REQUEST);
-    }
-
-    if (certificate.isExpired) {
-      throw new RuleError(CERTIFICATE_IS_EXPIRED, BAD_REQUEST);
-    }
-
-    return certificate;
-  }
-
+  
   async getCertificateByParams(params) {
     const certificate = await CertificateModel.findOne(params).exec();
 

--- a/modules/certificate/certificates.permission.js
+++ b/modules/certificate/certificates.permission.js
@@ -20,7 +20,7 @@ const {
 
 const certificatePermissionsQuery = {
   getCertificateById: hasRoles([ADMIN, SUPERADMIN]),
-  getCertificateByName: allow,
+  getCertificateByParams: allow,
   getAllCertificates: and(isAuthorized, isUnlocked),
 };
 

--- a/modules/certificate/certificates.permission.js
+++ b/modules/certificate/certificates.permission.js
@@ -1,4 +1,4 @@
-const { and, allow } = require('graphql-shield');
+const { and } = require('graphql-shield');
 const {
   hasRoles,
   isAuthorized,

--- a/modules/certificate/certificates.permission.js
+++ b/modules/certificate/certificates.permission.js
@@ -20,7 +20,6 @@ const {
 
 const certificatePermissionsQuery = {
   getCertificateById: hasRoles([ADMIN, SUPERADMIN]),
-  getCertificateByParams: allow,
   getAllCertificates: and(isAuthorized, isUnlocked),
 };
 

--- a/tests/certificate/certificate.helper.js
+++ b/tests/certificate/certificate.helper.js
@@ -89,11 +89,11 @@ const getCertificateById = async (id, operations) => {
   return result.data.getCertificateById;
 };
 
-const getCertificateByName = async (name, operations) => {
+const getCertificateByParams = async (params, operations) => {
   const result = await operations.query({
     query: gql`
-      query ($name: String!) {
-        getCertificateByName(name: $name) {
+      query ($params: CertificateInput!) {
+        getCertificateByParams(params: $params) {
           ... on Certificate {
             _id
             name
@@ -113,7 +113,7 @@ const getCertificateByName = async (name, operations) => {
       }
     `,
     variables: {
-      name,
+      params,
     },
   });
 
@@ -229,7 +229,7 @@ module.exports = {
   generateCertificate,
   getAllCertificates,
   getCertificateById,
-  getCertificateByName,
+  getCertificateByParams,
   registerUser,
   updateCertificate,
 };

--- a/tests/certificate/certificate.mutation.test.js
+++ b/tests/certificate/certificate.mutation.test.js
@@ -7,7 +7,7 @@ const {
   generateCertificate,
   updateCertificate,
   getCertificateById,
-  getCertificateByName
+  getCertificateByParams
 } = require('./certificate.helper');
 const {
   wrongId,
@@ -19,6 +19,7 @@ const {
 let operations;
 let certificateId;
 let certificateName;
+let certificateParams;
 let isUsed;
 
 describe('Test mutation methods Admin', () => {
@@ -36,6 +37,7 @@ describe('Test mutation methods Admin', () => {
     certificateId = result.certificates[0]._id;
     certificateName = result.certificates[0].name;
     isUsed = result.certificates[0].isUsed;
+    certificateParams = { name: certificateName };
 
     expect(result.certificates[0]).toHaveProperty('name');
   });
@@ -44,7 +46,7 @@ describe('Test mutation methods Admin', () => {
     expect(isUsed).toBeFalsy();
 
     const updateResult = await updateCertificate(certificateName, operations);
-    const getResult = await getCertificateByName(certificateName, operations);
+    const getResult = await getCertificateByParams(certificateParams, operations);
     
     expect(updateResult.isUsed).toBeTruthy();
     expect(getResult.errors[0]).toHaveProperty('message', CERTIFICATE_IS_USED);
@@ -59,7 +61,7 @@ describe('Test mutation methods Admin', () => {
 
   it('should delete certificate and throw error CERTIFICATE_NOT_FOUND', async () => {
     await deleteCertificate(certificateId, operations);
-    const result = await getCertificateByName(certificateName, operations);
+    const result = await getCertificateByParams(certificateParams, operations);
 
     expect(result.errors[0]).toHaveProperty('message', CERTIFICATE_NOT_FOUND);
   });

--- a/tests/certificate/certificate.permission.test.js
+++ b/tests/certificate/certificate.permission.test.js
@@ -15,7 +15,7 @@ const {
   generateCertificate,
   getAllCertificates,
   getCertificateById,
-  getCertificateByName,
+  getCertificateByParams,
   registerUser,
   updateCertificate,
 } = require('./certificate.helper');
@@ -30,6 +30,7 @@ describe('Run ApolloClientServer with role=admin in context', () => {
 
   let certificateId;
   let certificateName;
+  let certificateParams;
 
   let certificateNullOwnerId;
   let certificateNullOwnerEmail;
@@ -83,6 +84,7 @@ describe('Run ApolloClientServer with role=admin in context', () => {
       );
       certificateId = result.certificates[0]._id;
       certificateName = result.certificates[0].name;
+      certificateParams = { name: certificateName };
 
       expect(result.certificates[0]).toHaveProperty('name');
     });
@@ -115,9 +117,9 @@ describe('Run ApolloClientServer with role=admin in context', () => {
     });
 
     it('should get certificate by name', async () => {
-      const certificate = await getCertificateByName(certificateName, adminContextServer);
+      const certificate = await getCertificateByParams(certificateParams, adminContextServer);
 
-      expect(certificate.data.getCertificateByName).toHaveProperty('name', certificateName);
+      expect(certificate.data.getCertificateByParams).toHaveProperty('name', certificateName);
     });
 
   });
@@ -131,7 +133,7 @@ describe('Run ApolloClientServer with role=admin in context', () => {
 
     it('should update certificate and throw CERTIFICATE_IS_USED', async () => {
       await updateCertificate(certificateName, adminContextServer);
-      const certificate = await getCertificateByName(certificateName, adminContextServer);
+      const certificate = await getCertificateByParams(certificateParams, adminContextServer);
 
       expect(certificate.errors[0]).toHaveProperty('message', CERTIFICATE_IS_USED);
     });
@@ -170,9 +172,9 @@ describe('Run ApolloClientServer with role=admin in context', () => {
     });
 
     it('should delete certificate and throw CERTIFICATE_NOT_FOUND', async () => {
-      await deleteCertificate(certificateNullOwnerId, adminContextServer);
+      await deleteCertificate(certificateName, adminContextServer);
 
-      const certificate = await getCertificateByName(certificateNullOwnerName, adminContextServer);
+      const certificate = await getCertificateByParams(certificateParams, adminContextServer);
 
       expect(certificate.errors[0]).toHaveProperty('message', CERTIFICATE_NOT_FOUND);
     });

--- a/tests/certificate/certificate.query.test.js
+++ b/tests/certificate/certificate.query.test.js
@@ -7,7 +7,7 @@ const {
   generateCertificate,
   getAllCertificates,
   getCertificateById,
-  getCertificateByName,
+  getCertificateByParams,
   updateCertificate,
 } = require('./certificate.helper');
 const {
@@ -20,6 +20,7 @@ const {
 let operations;
 let certificateId;
 let certificateName;
+let certificateParams;
 
 describe('Test certificate Queries', () => {
   beforeAll(async () => {
@@ -31,6 +32,7 @@ describe('Test certificate Queries', () => {
     );
     certificateId = certificateData.certificates[0]._id;
     certificateName = certificateData.certificates[0].name;
+    certificateParams = { name: certificateName };
   });
 
   afterAll(async () => {
@@ -69,15 +71,15 @@ describe('Test certificate Queries', () => {
   });
 
   it('should get a fresh-generated certificate by name', async () => {
-    const result = await getCertificateByName(certificateName, operations);
-    expect(result.data.getCertificateByName).toHaveProperty('name', certificateName);
+    const result = await getCertificateByParams(certificateParams, operations);
+    expect(result.data.getCertificateByParams).toHaveProperty('name', certificateName);
   });
 
   it('should throw error CERTIFICATE_NOT_FOUND for get certificate by name', async () => {
-    const result = await getCertificateByName(wrongName, operations);
+    const result = await getCertificateByParams({ name: wrongName }, operations);
 
     expect(result.errors[0]).toHaveProperty('message', CERTIFICATE_NOT_FOUND);
-    expect(result.data.getCertificateByName).toEqual(null);
+    expect(result.data.getCertificateByParams).toEqual(null);
   });
   
 });


### PR DESCRIPTION
## Description

Delete redundant getCertificateByName and use getCertificateByParams instead.

#### Screenshots

### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [x] 🔗 Link pull request to issue
