### PR TITLE
Fixed appearance of non-own certificates

### DIFF
--- a/modules/certificate/certificate.graphql.js
+++ b/modules/certificate/certificate.graphql.js
@@ -64,7 +64,8 @@ const certificateTypes = `
   extend type Query {
     getAllCertificates(limit: Int, skip: Int, sortBy: String, sortOrder: Sort, search: String, status: [String]): CertificatePaginatedResult
     getCertificateById(id: ID!): CertificateResult
-    getCertificateByParams(params: CertificateInput!): CertificateResult
+    getCertificateByParams(params: CertificateInput!): CertificateResult,
+    getAllUserCertificates(limit: Int, skip: Int):CertificatePaginatedResult
   }
 
   extend type Mutation {

--- a/modules/certificate/certificate.resolver.js
+++ b/modules/certificate/certificate.resolver.js
@@ -24,10 +24,13 @@ const certificatesQuery = {
       user
     ),
 
+  getAllUserCertificates: async (_, { skip, limit }, { user }) =>
+    certificatesService.getAllUserCertificates(skip, limit, user),
+
   getCertificateById: async (_, { id }) =>
     certificatesService.getCertificateById(id),
 
-    getCertificateByParams: async (_, { params }) => {
+  getCertificateByParams: async (_, { params }) => {
     try {
       return await certificatesService.getCertificateByParams(params);
     } catch (e) {

--- a/modules/certificate/certificates.permission.js
+++ b/modules/certificate/certificates.permission.js
@@ -20,7 +20,8 @@ const {
 
 const certificatePermissionsQuery = {
   getCertificateById: hasRoles([ADMIN, SUPERADMIN]),
-  getAllCertificates: and(isAuthorized, isUnlocked),
+  getAllCertificates: hasRoles([ADMIN, SUPERADMIN]),
+  getAllUserCertificates: and(isAuthorized, isUnlocked),
 };
 
 const certificatePermissionsMutations = {

--- a/tests/certificate/certificate.helper.js
+++ b/tests/certificate/certificate.helper.js
@@ -34,7 +34,7 @@ const generateCertificate = async (certificateData, email, operations) => {
 const getAllCertificates = async (search, operations) => {
   const result = await operations.query({
     query: gql`
-      query($search: String) {
+      query ($search: String) {
         getAllCertificates(skip: 0, limit: 3, search: $search) {
           ... on PaginatedCertificate {
             items {
@@ -58,6 +58,32 @@ const getAllCertificates = async (search, operations) => {
 
   return result.data.getAllCertificates;
 };
+
+const getAllUserCertificates = async operations => {
+  const result = await operations.query({
+    query: gql`
+      query {
+        getAllUserCertificates(skip: 0, limit: 3) {
+          __typename
+          ... on PaginatedCertificate {
+            items {
+              _id
+              name
+              value
+              ownedBy {
+                _id
+              }
+            }
+            count
+          }
+        }
+      }
+    `,
+  });
+
+  return result.data.getAllUserCertificates;
+};
+
 const getCertificateById = async (id, operations) => {
   const result = await operations.query({
     query: gql`
@@ -117,7 +143,7 @@ const getCertificateByParams = async (params, operations) => {
     },
   });
 
-  return result
+  return result;
 };
 
 const addCertificate = async (certificateName, operations) => {
@@ -228,6 +254,7 @@ module.exports = {
   deleteCertificate,
   generateCertificate,
   getAllCertificates,
+  getAllUserCertificates,
   getCertificateById,
   getCertificateByParams,
   registerUser,

--- a/tests/certificate/certificate.permission.test.js
+++ b/tests/certificate/certificate.permission.test.js
@@ -14,6 +14,7 @@ const {
   deleteCertificate,
   generateCertificate,
   getAllCertificates,
+  getAllUserCertificates,
   getCertificateById,
   getCertificateByParams,
   registerUser,
@@ -106,8 +107,15 @@ describe('Run ApolloClientServer with role=admin in context', () => {
       expect(result).toHaveProperty('message', INVALID_PERMISSIONS);
     });
 
-    it('should see only certificates owned by him', async () => {
+    it('should not have access to all certificates', async () => {
       const result = await getAllCertificates(undefined, userContextServer);
+
+      expect(result).toHaveProperty('message', INVALID_PERMISSIONS);
+      expect(result).toHaveProperty('statusCode', 403);
+    });
+
+    it('should see only certificates owned by him', async () => {
+      const result = await getAllUserCertificates(userContextServer);
 
       expect(result.count).toBe(2);
     });
@@ -117,11 +125,16 @@ describe('Run ApolloClientServer with role=admin in context', () => {
     });
 
     it('should get certificate by name', async () => {
-      const certificate = await getCertificateByParams(certificateParams, adminContextServer);
+      const certificate = await getCertificateByParams(
+        certificateParams,
+        adminContextServer
+      );
 
-      expect(certificate.data.getCertificateByParams).toHaveProperty('name', certificateName);
+      expect(certificate.data.getCertificateByParams).toHaveProperty(
+        'name',
+        certificateName
+      );
     });
-
   });
 
   describe('Admin restrictions and cleaning DB', () => {
@@ -133,9 +146,15 @@ describe('Run ApolloClientServer with role=admin in context', () => {
 
     it('should update certificate and throw CERTIFICATE_IS_USED', async () => {
       await updateCertificate(certificateName, adminContextServer);
-      const certificate = await getCertificateByParams(certificateParams, adminContextServer);
+      const certificate = await getCertificateByParams(
+        certificateParams,
+        adminContextServer
+      );
 
-      expect(certificate.errors[0]).toHaveProperty('message', CERTIFICATE_IS_USED);
+      expect(certificate.errors[0]).toHaveProperty(
+        'message',
+        CERTIFICATE_IS_USED
+      );
     });
 
     it('shouldn`t use addCertificate method', async () => {
@@ -174,10 +193,15 @@ describe('Run ApolloClientServer with role=admin in context', () => {
     it('should delete certificate and throw CERTIFICATE_NOT_FOUND', async () => {
       await deleteCertificate(certificateName, adminContextServer);
 
-      const certificate = await getCertificateByParams(certificateParams, adminContextServer);
+      const certificate = await getCertificateByParams(
+        certificateParams,
+        adminContextServer
+      );
 
-      expect(certificate.errors[0]).toHaveProperty('message', CERTIFICATE_NOT_FOUND);
+      expect(certificate.errors[0]).toHaveProperty(
+        'message',
+        CERTIFICATE_NOT_FOUND
+      );
     });
-
   });
 });


### PR DESCRIPTION

### Now, even if your account has the "admin" role, only your own certificates will be displayed.

### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [x] 🔗 Link pull request to issue
