### PR TITLE
Feature/1265/Certificates sorting

### DIFF
--- a/helpers/filter-helper.js
+++ b/helpers/filter-helper.js
@@ -15,7 +15,7 @@ class FilterHelper {
 
     const searchPattern = {
       $regex: searchTrimmed,
-      $options: 'gi',
+      $options: 'i',
     };
 
     const searchFilter = {

--- a/modules/certificate/certificate.service.js
+++ b/modules/certificate/certificate.service.js
@@ -112,7 +112,18 @@ class CertificatesService extends FilterHelper {
       {
         $facet: {
           count: [{ $count: 'count' }],
-          data: [{ $skip: skip }, { $limit: limit }],
+          data: [
+            {
+              $sort: {
+                isUsed: 1,
+                isExpired: 1,
+                dateStart: 1,
+                value: -1,
+              },
+            },
+            { $skip: skip },
+            { $limit: limit },
+          ],
         },
       },
     ]).exec();

--- a/tests/certificate/certificate.permission.test.js
+++ b/tests/certificate/certificate.permission.test.js
@@ -191,7 +191,7 @@ describe('Run ApolloClientServer with role=admin in context', () => {
     });
 
     it('should delete certificate and throw CERTIFICATE_NOT_FOUND', async () => {
-      await deleteCertificate(certificateName, adminContextServer);
+      await deleteCertificate(certificateId, adminContextServer);
 
       const certificate = await getCertificateByParams(
         certificateParams,

--- a/tests/filter-helper/filter-helper.helper.js
+++ b/tests/filter-helper/filter-helper.helper.js
@@ -4,25 +4,25 @@ const filtration = {
       $or: [
         {
           'admin.firstName': {
-            $options: 'gi',
+            $options: 'i',
             $regex: 'test',
           },
         },
         {
           'admin.lastName': {
-            $options: 'gi',
+            $options: 'i',
             $regex: 'test',
           },
         },
         {
           name: {
-            $options: 'gi',
+            $options: 'i',
             $regex: 'test',
           },
         },
         {
           code: {
-            $options: 'gi',
+            $options: 'i',
             $regex: 'test',
           },
         },


### PR DESCRIPTION
## Description

Add certificates sorting to sort by the `isUsed`, `isExpired`, `dateStart` and `value` fields.

### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [x] 🔗 Link pull request to issue
