### PR TITLE
payment status changing

### DIFF
--- a/modules/order/order.service.js
+++ b/modules/order/order.service.js
@@ -265,6 +265,12 @@ class OrdersService {
     }
     totalPriceToPay = Math.round(totalPriceToPay);
 
+    let paymentStatus = order?.paymentStatus;
+
+    if (order.paymentMethod === 'CASH') {
+      paymentStatus = order.isPaid ? 'PAID' : paymentStatus;
+    }
+
     const newOrder = {
       ...data,
       totalItemsPrice,
@@ -272,6 +278,7 @@ class OrdersService {
       itemsPriceWithDiscount,
       itemsDiscount,
       orderNumber,
+      paymentStatus,
       fixedExchangeRate: exchangeRate,
     };
 

--- a/modules/order/order.service.js
+++ b/modules/order/order.service.js
@@ -36,6 +36,8 @@ const {
   getCertificateByParams,
   updateCertificate,
 } = require('../certificate/certificate.service');
+const { ORDER_PAYMENT_STATUS } = require('../../consts/order-payment-status');
+const { PAYMENT_TYPES } = require('../../consts/payment-types.js');
 
 class OrdersService {
   async getAllOrders({ skip, limit, filter = {}, sort }) {
@@ -177,10 +179,10 @@ class OrdersService {
     }
 
     const { items } = order;
+    const { user_id } = orderToUpdate;
+    let { paymentStatus } = orderToUpdate;
 
-    const userId = orderToUpdate?.user_id;
-
-    const data = { ...order, user_id: userId || null };
+    const data = { ...order, user_id };
 
     await updateProductStatistic(orderToUpdate, data);
 
@@ -208,10 +210,11 @@ class OrdersService {
         (await calculateTotalPriceToPay(itemsPriceWithDiscount)) -
         itemsDiscount / exchangeRate;
     }
-    let paymentStatus = order?.paymentStatus;
 
-    if (order.paymentMethod === 'CASH') {
-      paymentStatus = order.isPaid ? 'PAID' : 'CREATED';
+    if (order.paymentMethod === PAYMENT_TYPES.CASH) {
+      paymentStatus = order.isPaid
+        ? ORDER_PAYMENT_STATUS.PAID
+        : ORDER_PAYMENT_STATUS.CREATED;
     }
 
     const orderUpdate = {
@@ -232,6 +235,7 @@ class OrdersService {
 
   async addOrder(order, user) {
     const { items } = order;
+    let { paymentStatus } = order;
 
     const data = { ...order, user_id: user ? user._id : null };
     await addProductsToStatistic(items);
@@ -265,10 +269,10 @@ class OrdersService {
     }
     totalPriceToPay = Math.round(totalPriceToPay);
 
-    let paymentStatus = order?.paymentStatus;
-
-    if (order.paymentMethod === 'CASH') {
-      paymentStatus = order.isPaid ? 'PAID' : paymentStatus;
+    if (order.paymentMethod === PAYMENT_TYPES.CASH) {
+      paymentStatus = order.isPaid
+        ? ORDER_PAYMENT_STATUS.PAID
+        : ORDER_PAYMENT_STATUS.CREATED;
     }
 
     const newOrder = {

--- a/modules/order/order.service.js
+++ b/modules/order/order.service.js
@@ -208,6 +208,11 @@ class OrdersService {
         (await calculateTotalPriceToPay(itemsPriceWithDiscount)) -
         itemsDiscount / exchangeRate;
     }
+    let paymentStatus = order?.paymentStatus;
+
+    if (order.paymentMethod === 'CASH') {
+      paymentStatus = order.isPaid ? 'PAID' : 'CREATED';
+    }
 
     const orderUpdate = {
       ...order,
@@ -215,6 +220,7 @@ class OrdersService {
       itemsPriceWithDiscount,
       itemsDiscount,
       totalPriceToPay,
+      paymentStatus,
     };
 
     return Order.findByIdAndUpdate(

--- a/tests/order/order.query.test.js
+++ b/tests/order/order.query.test.js
@@ -81,6 +81,7 @@ let userId;
 let certificateId;
 let certificateName;
 let certificateParams;
+let isPaid;
 
 const date = { dateFrom: '', dateTo: '' };
 
@@ -338,15 +339,44 @@ describe('Order queries', () => {
     expect(order).toHaveProperty('status', status);
   });
 
-  test('Should update order', async () => {
+  test('Should update order and return paid', async () => {
+    isPaid = true;
     const updatedOrder = await updateOrderById(
-      newOrderUpdated(productId, modelId, sizeId, undefined, certificateId),
+      newOrderUpdated(
+        productId,
+        modelId,
+        sizeId,
+        undefined,
+        certificateId,
+        isPaid
+      ),
       orderId,
       operations
     );
 
     expect(updatedOrder).toBeTruthy();
     expect(updatedOrder).toHaveProperty('certificateId', certificateId);
+    expect(updatedOrder.paymentStatus).toBe('PAID');
+  });
+
+  test('Should update order and return create', async () => {
+    isPaid = false;
+    const updatedOrder = await updateOrderById(
+      newOrderUpdated(
+        productId,
+        modelId,
+        sizeId,
+        undefined,
+        certificateId,
+        isPaid
+      ),
+      orderId,
+      operations
+    );
+
+    expect(updatedOrder).toBeTruthy();
+    expect(updatedOrder).toHaveProperty('certificateId', certificateId);
+    expect(updatedOrder.paymentStatus).toBe('CREATED');
   });
 
   test('Should throw error ORDER_NOT_FOUND', async () => {

--- a/tests/order/order.variables.js
+++ b/tests/order/order.variables.js
@@ -1,7 +1,6 @@
 const wrongId = '5fb412d8663cf10bec9faa1a';
 const email = 'test@test.com';
 const orderStatus = 'CREATED';
-const paymentStatus = 'CREATED';
 const price = 2;
 const getOrdersInput = {
   filter: {
@@ -26,7 +25,8 @@ const newOrderInputData = (
   sizeId,
   constructorId,
   userId,
-  certificateId
+  certificateId,
+  isPaid
 ) => ({
   status: orderStatus,
   recipient: {
@@ -56,8 +56,9 @@ const newOrderInputData = (
       price,
     },
   ],
+  isPaid,
   paymentMethod: 'CASH',
-  paymentStatus,
+  paymentStatus: isPaid ? 'PAID' : 'CREATED',
   certificateId,
   user_id: userId,
 });
@@ -66,7 +67,8 @@ const newOrderUpdated = (
   modelId,
   sizeId,
   constructorId,
-  certificateId
+  certificateId,
+  isPaid
 ) => ({
   status: 'SENT',
   recipient: {
@@ -96,8 +98,9 @@ const newOrderUpdated = (
       price,
     },
   ],
+  isPaid,
   paymentMethod: 'CASH',
-  paymentStatus: 'CREATED',
+  paymentStatus: isPaid ? 'PAID' : 'CREATED',
   promoCodeId: '',
   certificateId,
 });
@@ -110,5 +113,4 @@ module.exports = {
   email,
   newOrderUpdated,
   orderStatus,
-  paymentStatus,
 };

--- a/tests/order/order.variables.js
+++ b/tests/order/order.variables.js
@@ -61,7 +61,13 @@ const newOrderInputData = (
   certificateId,
   user_id: userId,
 });
-const newOrderUpdated = (productId, modelId, sizeId, constructorId, certificateId) => ({
+const newOrderUpdated = (
+  productId,
+  modelId,
+  sizeId,
+  constructorId,
+  certificateId
+) => ({
   status: 'SENT',
   recipient: {
     firstName: 'Updated',
@@ -91,9 +97,9 @@ const newOrderUpdated = (productId, modelId, sizeId, constructorId, certificateI
     },
   ],
   paymentMethod: 'CASH',
-  paymentStatus: 'APPROVED',
+  paymentStatus: 'CREATED',
   promoCodeId: '',
-  certificateId
+  certificateId,
 });
 
 module.exports = {


### PR DESCRIPTION
## Description

When we change a checkbox on paid, the payment status does not change. But now it works when we create and change an order.


#### Screenshots

1) Go to Orders page.
![Order create](https://user-images.githubusercontent.com/83120263/199995483-32d839d0-e5ef-4ca8-88f8-42071c6ae310.jpg)

2) Click on edit order icon.

3) Change payment checkbox to true.
![Order is paid](https://user-images.githubusercontent.com/83120263/199995535-d5ffbce1-23d4-466d-ac9c-bb62cbd553da.jpg)

4) Return back to orders page, and payment status does not change.
![Satus is refreshes](https://user-images.githubusercontent.com/83120263/199995655-03ec5ca7-8816-42f6-bec5-e7c8f52c2063.jpg)



### Checklist
- [x] 🔽 My branch is up-to-date with "development" branch
- [x] ✅All tests passed locally
- [x] ✨My changes working with up-to-date front-end and admin part locally, like charm
- [x] 🔗 Link pull request to issue
